### PR TITLE
Feature/crud groups patients teams

### DIFF
--- a/src/caregivers/caregivers.module.ts
+++ b/src/caregivers/caregivers.module.ts
@@ -8,9 +8,7 @@ import { AuthModule } from 'src/auth/auth.module';
 @Module({
   controllers: [CaregiversController],
   providers: [CaregiversService],
-  imports: [
-    TypeOrmModule.forFeature([Caregiver]),
-    AuthModule
-  ],
+  imports: [TypeOrmModule.forFeature([Caregiver]), AuthModule],
+  exports: [TypeOrmModule],
 })
-export class CaregiversModule { }
+export class CaregiversModule {}

--- a/src/groups/dto/create-group.dto.ts
+++ b/src/groups/dto/create-group.dto.ts
@@ -1,14 +1,12 @@
-import { ApiProperty } from "@nestjs/swagger";
-import { IsString, MinLength } from "class-validator";
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, MinLength } from 'class-validator';
 
 export class CreateGroupDto {
-
   @ApiProperty({
     description: `Group`,
-    example: 'Group 1'
+    example: 'Group 1',
   })
   @IsString()
   @MinLength(1)
   groupName: string;
-
 }

--- a/src/groups/entities/group.entity.ts
+++ b/src/groups/entities/group.entity.ts
@@ -1,23 +1,17 @@
-import { Team } from "src/teams/entities/team.entity";
-import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from "typeorm";
+import { Team } from 'src/teams/entities/team.entity';
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity({ name: 'groups' })
 export class Group {
-
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
   @Column('text', {
     unique: true,
-    nullable: false
+    nullable: false,
   })
   groupName: string;
 
-  @OneToMany(
-    () => Team,
-    (team) => team.group,
-    { cascade: true },
-  )
+  @OneToMany(() => Team, (team) => team.group, { cascade: true })
   team: Team;
-
 }

--- a/src/groups/groups.controller.ts
+++ b/src/groups/groups.controller.ts
@@ -1,36 +1,99 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  ParseUUIDPipe,
+  Query,
+} from '@nestjs/common';
 import { GroupsService } from './groups.service';
 import { CreateGroupDto } from './dto/create-group.dto';
 import { UpdateGroupDto } from './dto/update-group.dto';
-import { ApiTags } from '@nestjs/swagger';
+import {
+  ApiBody,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
+import { PaginationDto } from 'src/common/dto/pagination.dto';
+import { Auth } from 'src/auth/decorators/auth.decorator';
+import { Role } from 'src/users/entities/user.entity';
 
-@ApiTags('Groups not available!')
+@ApiTags('Groups')
 @Controller('groups')
 export class GroupsController {
   constructor(private readonly groupsService: GroupsService) {}
 
   @Post()
+  @Auth(Role.ADMIN)
+  @ApiOperation({ summary: 'Create a group' })
+  @ApiBody({ type: CreateGroupDto })
   create(@Body() createGroupDto: CreateGroupDto) {
     return this.groupsService.create(createGroupDto);
   }
 
   @Get()
-  findAll() {
-    return this.groupsService.findAll();
+  @Auth(Role.ADMIN)
+  @ApiOperation({ summary: 'Obtain all groups' })
+  @ApiQuery({
+    name: 'limit',
+    description: 'Number of results per page',
+    required: false,
+    type: Number,
+    default: 10,
+  })
+  @ApiQuery({
+    name: 'page',
+    description: 'What page do you need',
+    required: false,
+    type: Number,
+    default: 1,
+  })
+  findAll(@Query() paginationDto: PaginationDto) {
+    return this.groupsService.findAll(paginationDto);
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.groupsService.findOne(+id);
+  @Auth(Role.ADMIN)
+  @ApiOperation({ summary: 'Obtain one group' })
+  @ApiParam({
+    name: 'id',
+    description: 'The id of the group to obtain',
+    type: String,
+  })
+  findOne(@Param('id', ParseUUIDPipe) id: string) {
+    return this.groupsService.findOne(id);
   }
 
   @Patch(':id')
-  update(@Param('id') id: string, @Body() updateGroupDto: UpdateGroupDto) {
-    return this.groupsService.update(+id, updateGroupDto);
+  @Auth(Role.ADMIN)
+  @ApiOperation({ summary: 'Update a group' })
+  @ApiParam({
+    name: 'id',
+    type: String,
+    description: 'Group ID to be updated (UUID)',
+  })
+  @ApiBody({ type: UpdateGroupDto })
+  update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() updateGroupDto: UpdateGroupDto,
+  ) {
+    return this.groupsService.update(id, updateGroupDto);
   }
 
   @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.groupsService.remove(+id);
+  @Auth(Role.ADMIN)
+  @ApiOperation({ summary: 'Remove a group' })
+  @ApiParam({
+    name: 'id',
+    type: String,
+    description: 'Group ID to be removed (UUID)',
+  })
+  remove(@Param('id', ParseUUIDPipe) id: string) {
+    return this.groupsService.remove(id);
   }
 }

--- a/src/groups/groups.module.ts
+++ b/src/groups/groups.module.ts
@@ -3,12 +3,12 @@ import { GroupsService } from './groups.service';
 import { GroupsController } from './groups.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Group } from './entities/group.entity';
+import { AuthModule } from 'src/auth/auth.module';
 
 @Module({
   controllers: [GroupsController],
   providers: [GroupsService],
-  imports: [
-    TypeOrmModule.forFeature([Group])
-  ]
+  imports: [TypeOrmModule.forFeature([Group]), AuthModule],
+  exports: [TypeOrmModule, GroupsService],
 })
 export class GroupsModule {}

--- a/src/groups/groups.service.ts
+++ b/src/groups/groups.service.ts
@@ -1,26 +1,64 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException, Logger } from '@nestjs/common';
 import { CreateGroupDto } from './dto/create-group.dto';
 import { UpdateGroupDto } from './dto/update-group.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Group } from './entities/group.entity';
+import { Repository } from 'typeorm';
+import { PaginationDto } from 'src/common/dto/pagination.dto';
+import { handleDBExceptions, emptyDtoException } from 'src/common/utils';
 
 @Injectable()
 export class GroupsService {
-  create(createGroupDto: CreateGroupDto) {
-    return 'This action adds a new group';
+  private readonly logger = new Logger(GroupsService.name);
+
+  constructor(
+    @InjectRepository(Group)
+    private readonly groupRepository: Repository<Group>,
+  ) {}
+
+  async create(createGroupDto: CreateGroupDto) {
+    try {
+      const group = this.groupRepository.create(createGroupDto);
+      await this.groupRepository.save(group);
+      return { message: 'Group created successfully', group };
+    } catch (error) {
+      handleDBExceptions(error, this.logger);
+    }
   }
 
-  findAll() {
-    return `This action returns all groups`;
+  async findAll(paginationDto: PaginationDto) {
+    const { limit = 10, page = 1 } = paginationDto;
+    const offset = (page - 1) * limit;
+
+    const [groups, total] = await this.groupRepository.findAndCount({
+      take: limit,
+      skip: offset,
+    });
+
+    return { groups, total };
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} group`;
+  async findOne(id: string) {
+    const group = await this.groupRepository.findOne({ where: { id } });
+    if (!group) {
+      throw new NotFoundException(`Group with id ${id} not found`);
+    }
+    return group;
   }
 
-  update(id: number, updateGroupDto: UpdateGroupDto) {
-    return `This action updates a #${id} group`;
+  async update(id: string, updateGroupDto: UpdateGroupDto) {
+    emptyDtoException(updateGroupDto);
+
+    const group = await this.findOne(id);
+    const updatedGroup = { ...group, ...updateGroupDto };
+
+    await this.groupRepository.save(updatedGroup);
+    return { message: 'Group updated successfully', updatedGroup };
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} group`;
+  async remove(id: string) {
+    const group = await this.findOne(id);
+    await this.groupRepository.remove(group);
+    return { message: `Group with ID ${id} deleted successfully` };
   }
 }

--- a/src/patients/dto/create-patient.dto.ts
+++ b/src/patients/dto/create-patient.dto.ts
@@ -1,1 +1,91 @@
-export class CreatePatientDto {}
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsString,
+  IsEnum,
+  IsDate,
+  IsInt,
+  IsBoolean,
+  IsUUID,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { Gender } from '../entities/patient.entity';
+
+export class CreatePatientDto {
+  @ApiProperty({
+    description: `Patient document`,
+    example: '1234567890',
+  })
+  @IsString()
+  document: string;
+
+  @ApiProperty({
+    description: `Patient name`,
+    example: 'John',
+  })
+  @IsString()
+  name: string;
+
+  @ApiProperty({
+    description: `Patient last name`,
+    example: 'Doe',
+  })
+  @IsString()
+  lastName: string;
+
+  @ApiProperty({
+    description: `Patient gender`,
+    example: Gender.MALE,
+  })
+  @IsEnum(Gender)
+  gender: Gender;
+
+  @ApiProperty({
+    description: `Patient birthday`,
+    example: '1990-01-01',
+  })
+  @IsDate()
+  @Type(() => Date)
+  birthday: Date;
+
+  @ApiProperty({
+    description: `Type of beneficiary`,
+    example: 'Type A',
+  })
+  @IsString()
+  typeBeneficiary: string;
+
+  @ApiProperty({
+    description: `Type of disability`,
+    example: 'Physical',
+  })
+  @IsString()
+  typeDisability: string;
+
+  @ApiProperty({
+    description: `Percentage of disability`,
+    example: 50,
+  })
+  @IsInt()
+  percentageDisability: number;
+
+  @ApiProperty({
+    description: `Zone`,
+    example: 'Urban',
+  })
+  @IsString()
+  zone: string;
+
+  @ApiProperty({
+    description: `Is active`,
+    example: true,
+  })
+  @IsBoolean()
+  isActive: boolean;
+
+  @ApiProperty({
+    description: `Caregiver ID`,
+    example: 'uuid-of-caregiver',
+  })
+  @IsUUID()
+  caregiverId: string;
+}

--- a/src/patients/entities/patient.entity.ts
+++ b/src/patients/entities/patient.entity.ts
@@ -1,6 +1,12 @@
-import { Caregiver } from "src/caregivers/entities/caregiver.entity";
-import { Team } from "src/teams/entities/team.entity";
-import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Caregiver } from 'src/caregivers/entities/caregiver.entity';
+import { Team } from 'src/teams/entities/team.entity';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 
 export enum Gender {
   MALE = 'male',
@@ -9,44 +15,43 @@ export enum Gender {
 
 @Entity({ name: 'patients' })
 export class Patient {
-
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
   @Column('text', {
     unique: true,
-    nullable: false
+    nullable: false,
   })
   document: string;
 
   @Column('text', {
-    nullable: false
+    nullable: false,
   })
   name: string;
 
   @Column('text', {
-    nullable: false
+    nullable: false,
   })
   lastName: string;
 
   @Column('enum', {
     enum: Gender,
-    nullable: false
+    nullable: false,
   })
   gender: Gender;
 
   @Column('date', {
-    nullable: false
+    nullable: false,
   })
   birthday: Date;
 
   @Column('text', {
-    nullable: false
+    nullable: false,
   })
   typeBeneficiary: string;
 
   @Column('text', {
-    nullable: false
+    nullable: false,
   })
   typeDisability: string;
 
@@ -56,7 +61,7 @@ export class Patient {
   percentageDisability: number;
 
   @Column('text', {
-    nullable: false
+    nullable: false,
   })
   zone: string;
 
@@ -66,19 +71,12 @@ export class Patient {
   })
   isActive: boolean;
 
-  @OneToOne(
-    () => Caregiver,
-    (caregiver) => caregiver.patient,
-    { nullable: false }
-  )
+  @OneToOne(() => Caregiver, (caregiver) => caregiver.patient, {
+    nullable: false,
+  })
   @JoinColumn()
   caregiver: Caregiver;
 
-  @OneToOne(
-    () => Team,
-    (team) => team.patient,
-    { cascade: true }
-  )
+  @OneToOne(() => Team, (team) => team.patient, { cascade: true })
   team: Team;
-
 }

--- a/src/patients/patients.controller.ts
+++ b/src/patients/patients.controller.ts
@@ -1,36 +1,99 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  ParseUUIDPipe,
+  Query,
+} from '@nestjs/common';
 import { PatientsService } from './patients.service';
 import { CreatePatientDto } from './dto/create-patient.dto';
 import { UpdatePatientDto } from './dto/update-patient.dto';
-import { ApiTags } from '@nestjs/swagger';
+import {
+  ApiBody,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
+import { PaginationDto } from 'src/common/dto/pagination.dto';
+import { Auth } from 'src/auth/decorators/auth.decorator';
+import { Role } from 'src/users/entities/user.entity';
 
-@ApiTags('Patients not available!')
+@ApiTags('Patients')
 @Controller('patients')
 export class PatientsController {
   constructor(private readonly patientsService: PatientsService) {}
 
   @Post()
+  @Auth(Role.ADMIN)
+  @ApiOperation({ summary: 'Create a patient' })
+  @ApiBody({ type: CreatePatientDto })
   create(@Body() createPatientDto: CreatePatientDto) {
     return this.patientsService.create(createPatientDto);
   }
 
   @Get()
-  findAll() {
-    return this.patientsService.findAll();
+  @Auth(Role.ADMIN)
+  @ApiOperation({ summary: 'Obtain all patients' })
+  @ApiQuery({
+    name: 'limit',
+    description: 'Number of results per page',
+    required: false,
+    type: Number,
+    default: 10,
+  })
+  @ApiQuery({
+    name: 'page',
+    description: 'What page do you need',
+    required: false,
+    type: Number,
+    default: 1,
+  })
+  findAll(@Query() paginationDto: PaginationDto) {
+    return this.patientsService.findAll(paginationDto);
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.patientsService.findOne(+id);
+  @Auth(Role.ADMIN)
+  @ApiOperation({ summary: 'Obtain one patient' })
+  @ApiParam({
+    name: 'id',
+    description: 'The id of the patient to obtain',
+    type: String,
+  })
+  findOne(@Param('id', ParseUUIDPipe) id: string) {
+    return this.patientsService.findOne(id);
   }
 
   @Patch(':id')
-  update(@Param('id') id: string, @Body() updatePatientDto: UpdatePatientDto) {
-    return this.patientsService.update(+id, updatePatientDto);
+  @Auth(Role.ADMIN)
+  @ApiOperation({ summary: 'Update a patient' })
+  @ApiParam({
+    name: 'id',
+    type: String,
+    description: 'Patient ID to be updated (UUID)',
+  })
+  @ApiBody({ type: UpdatePatientDto })
+  update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() updatePatientDto: UpdatePatientDto,
+  ) {
+    return this.patientsService.update(id, updatePatientDto);
   }
 
   @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.patientsService.remove(+id);
+  @Auth(Role.ADMIN)
+  @ApiOperation({ summary: 'Remove a patient' })
+  @ApiParam({
+    name: 'id',
+    type: String,
+    description: 'Patient ID to be removed (UUID)',
+  })
+  remove(@Param('id', ParseUUIDPipe) id: string) {
+    return this.patientsService.remove(id);
   }
 }

--- a/src/patients/patients.module.ts
+++ b/src/patients/patients.module.ts
@@ -3,12 +3,18 @@ import { PatientsService } from './patients.service';
 import { PatientsController } from './patients.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Patient } from './entities/patient.entity';
+import { Caregiver } from 'src/caregivers/entities/caregiver.entity';
+import { AuthModule } from 'src/auth/auth.module';
+import { CaregiversModule } from 'src/caregivers/caregivers.module';
 
 @Module({
   controllers: [PatientsController],
   providers: [PatientsService],
   imports: [
-    TypeOrmModule.forFeature([Patient])
+    TypeOrmModule.forFeature([Patient, Caregiver]),
+    AuthModule,
+    CaregiversModule,
   ],
+  exports: [TypeOrmModule, PatientsService],
 })
 export class PatientsModule {}

--- a/src/patients/patients.service.ts
+++ b/src/patients/patients.service.ts
@@ -1,26 +1,77 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException, Logger } from '@nestjs/common';
 import { CreatePatientDto } from './dto/create-patient.dto';
 import { UpdatePatientDto } from './dto/update-patient.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Patient } from './entities/patient.entity';
+import { Repository } from 'typeorm';
+import { PaginationDto } from 'src/common/dto/pagination.dto';
+import { handleDBExceptions, emptyDtoException } from 'src/common/utils';
+import { Caregiver } from 'src/caregivers/entities/caregiver.entity';
 
 @Injectable()
 export class PatientsService {
-  create(createPatientDto: CreatePatientDto) {
-    return 'This action adds a new patient';
+  private readonly logger = new Logger(PatientsService.name);
+
+  constructor(
+    @InjectRepository(Patient)
+    private readonly patientRepository: Repository<Patient>,
+    @InjectRepository(Caregiver)
+    private readonly caregiverRepository: Repository<Caregiver>,
+  ) {}
+
+  async create(createPatientDto: CreatePatientDto) {
+    try {
+      const { caregiverId, ...patientData } = createPatientDto;
+
+      const caregiver = await this.caregiverRepository.findOne({
+        where: { id: caregiverId },
+      });
+
+      const patient = this.patientRepository.create({
+        ...patientData,
+        caregiver,
+      });
+
+      await this.patientRepository.save(patient);
+      return { message: 'Patient created successfully', patient };
+    } catch (error) {
+      handleDBExceptions(error, this.logger);
+    }
   }
 
-  findAll() {
-    return `This action returns all patients`;
+  async findAll(paginationDto: PaginationDto) {
+    const { limit = 10, page = 1 } = paginationDto;
+    const offset = (page - 1) * limit;
+
+    const [patients, total] = await this.patientRepository.findAndCount({
+      take: limit,
+      skip: offset,
+    });
+
+    return { patients, total };
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} patient`;
+  async findOne(id: string) {
+    const patient = await this.patientRepository.findOne({ where: { id } });
+    if (!patient) {
+      throw new NotFoundException(`Patient with id ${id} not found`);
+    }
+    return patient;
   }
 
-  update(id: number, updatePatientDto: UpdatePatientDto) {
-    return `This action updates a #${id} patient`;
+  async update(id: string, updatePatientDto: UpdatePatientDto) {
+    emptyDtoException(updatePatientDto);
+
+    const patient = await this.findOne(id);
+    const updatedPatient = { ...patient, ...updatePatientDto };
+
+    await this.patientRepository.save(updatedPatient);
+    return { message: 'Patient updated successfully', updatedPatient };
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} patient`;
+  async remove(id: string) {
+    const patient = await this.findOne(id);
+    await this.patientRepository.remove(patient);
+    return { message: `Patient with ID ${id} deleted successfully` };
   }
 }

--- a/src/teams/dto/create-team.dto.ts
+++ b/src/teams/dto/create-team.dto.ts
@@ -1,1 +1,25 @@
-export class CreateTeamDto {}
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsUUID } from 'class-validator';
+
+export class CreateTeamDto {
+  @ApiProperty({
+    description: `Team name`,
+    example: 'Team A',
+  })
+  @IsString()
+  teamName: string;
+
+  @ApiProperty({
+    description: `Group ID`,
+    example: 'uuid-of-group',
+  })
+  @IsUUID()
+  groupId: string;
+
+  @ApiProperty({
+    description: `Patient ID`,
+    example: 'uuid-of-patient',
+  })
+  @IsUUID()
+  patientId: string;
+}

--- a/src/teams/entities/team.entity.ts
+++ b/src/teams/entities/team.entity.ts
@@ -1,40 +1,36 @@
-import { Group } from "src/groups/entities/group.entity";
-import { Patient } from "src/patients/entities/patient.entity";
-import { User } from "src/users/entities/user.entity";
-import { Column, Entity, JoinColumn, ManyToOne, OneToMany, OneToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Group } from 'src/groups/entities/group.entity';
+import { Patient } from 'src/patients/entities/patient.entity';
+import { User } from 'src/users/entities/user.entity';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 
 @Entity({ name: 'teams' })
 export class Team {
-
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
   @Column('text', {
     unique: true,
-    nullable: false
+    nullable: false,
+    name: 'team_name',
   })
   teamName: string;
 
-  @ManyToOne(
-    () => Group,
-    (group) => group.team,
-    { nullable: true }
-  )
+  @ManyToOne(() => Group, (group) => group.team, { nullable: false })
+  @JoinColumn({ name: 'group_id' })
   group: Group;
 
-  @OneToOne(
-    () => Patient,
-    (patient) => patient.team,
-    { nullable: true }
-  )
-  @JoinColumn()
+  @OneToOne(() => Patient, (patient) => patient.team, { nullable: false })
+  @JoinColumn({ name: 'patient_id' })
   patient: Patient;
 
-  @OneToMany(
-    () => User,
-    (user) => user.team,
-    { cascade: true },
-  )
+  @OneToMany(() => User, (user) => user.team, { cascade: true })
   user: User;
-
 }

--- a/src/teams/teams.controller.ts
+++ b/src/teams/teams.controller.ts
@@ -1,36 +1,99 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  ParseUUIDPipe,
+  Query,
+} from '@nestjs/common';
 import { TeamsService } from './teams.service';
 import { CreateTeamDto } from './dto/create-team.dto';
 import { UpdateTeamDto } from './dto/update-team.dto';
-import { ApiTags } from '@nestjs/swagger';
+import {
+  ApiBody,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
+import { PaginationDto } from 'src/common/dto/pagination.dto';
+import { Auth } from 'src/auth/decorators/auth.decorator';
+import { Role } from 'src/users/entities/user.entity';
 
-@ApiTags('Teams not available!')
+@ApiTags('Teams')
 @Controller('teams')
 export class TeamsController {
   constructor(private readonly teamsService: TeamsService) {}
 
   @Post()
+  @Auth(Role.ADMIN)
+  @ApiOperation({ summary: 'Create a team' })
+  @ApiBody({ type: CreateTeamDto })
   create(@Body() createTeamDto: CreateTeamDto) {
     return this.teamsService.create(createTeamDto);
   }
 
   @Get()
-  findAll() {
-    return this.teamsService.findAll();
+  @Auth(Role.ADMIN)
+  @ApiOperation({ summary: 'Obtain all teams' })
+  @ApiQuery({
+    name: 'limit',
+    description: 'Number of results per page',
+    required: false,
+    type: Number,
+    default: 10,
+  })
+  @ApiQuery({
+    name: 'page',
+    description: 'What page do you need',
+    required: false,
+    type: Number,
+    default: 1,
+  })
+  findAll(@Query() paginationDto: PaginationDto) {
+    return this.teamsService.findAll(paginationDto);
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.teamsService.findOne(+id);
+  @Auth(Role.ADMIN)
+  @ApiOperation({ summary: 'Obtain one team' })
+  @ApiParam({
+    name: 'id',
+    description: 'The id of the team to obtain',
+    type: String,
+  })
+  findOne(@Param('id', ParseUUIDPipe) id: string) {
+    return this.teamsService.findOne(id);
   }
 
   @Patch(':id')
-  update(@Param('id') id: string, @Body() updateTeamDto: UpdateTeamDto) {
-    return this.teamsService.update(+id, updateTeamDto);
+  @Auth(Role.ADMIN)
+  @ApiOperation({ summary: 'Update a team' })
+  @ApiParam({
+    name: 'id',
+    type: String,
+    description: 'Team ID to be updated (UUID)',
+  })
+  @ApiBody({ type: UpdateTeamDto })
+  update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() updateTeamDto: UpdateTeamDto,
+  ) {
+    return this.teamsService.update(id, updateTeamDto);
   }
 
   @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.teamsService.remove(+id);
+  @Auth(Role.ADMIN)
+  @ApiOperation({ summary: 'Remove a team' })
+  @ApiParam({
+    name: 'id',
+    type: String,
+    description: 'Team ID to be removed (UUID)',
+  })
+  remove(@Param('id', ParseUUIDPipe) id: string) {
+    return this.teamsService.remove(id);
   }
 }

--- a/src/teams/teams.module.ts
+++ b/src/teams/teams.module.ts
@@ -3,12 +3,21 @@ import { TeamsService } from './teams.service';
 import { TeamsController } from './teams.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Team } from './entities/team.entity';
+import { Patient } from 'src/patients/entities/patient.entity';
+import { Group } from 'src/groups/entities/group.entity';
+import { AuthModule } from 'src/auth/auth.module';
+import { PatientsModule } from 'src/patients/patients.module';
+import { GroupsModule } from 'src/groups/groups.module';
 
 @Module({
   controllers: [TeamsController],
   providers: [TeamsService],
   imports: [
-    TypeOrmModule.forFeature([Team])
-  ]
+    TypeOrmModule.forFeature([Team, Patient, Group]),
+    AuthModule,
+    PatientsModule,
+    GroupsModule,
+  ],
+  exports: [TypeOrmModule, TeamsService],
 })
 export class TeamsModule {}

--- a/src/teams/teams.service.ts
+++ b/src/teams/teams.service.ts
@@ -1,26 +1,84 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException, Logger } from '@nestjs/common';
 import { CreateTeamDto } from './dto/create-team.dto';
 import { UpdateTeamDto } from './dto/update-team.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Team } from './entities/team.entity';
+import { Repository } from 'typeorm';
+import { PaginationDto } from 'src/common/dto/pagination.dto';
+import { handleDBExceptions, emptyDtoException } from 'src/common/utils';
+import { Patient } from 'src/patients/entities/patient.entity';
+import { Group } from 'src/groups/entities/group.entity';
 
 @Injectable()
 export class TeamsService {
-  create(createTeamDto: CreateTeamDto) {
-    return 'This action adds a new team';
+  private readonly logger = new Logger(TeamsService.name);
+
+  constructor(
+    @InjectRepository(Team)
+    private readonly teamRepository: Repository<Team>,
+    @InjectRepository(Patient)
+    private readonly patientRepository: Repository<Patient>,
+    @InjectRepository(Group)
+    private readonly groupRepository: Repository<Group>,
+  ) {}
+
+  async create(createTeamDto: CreateTeamDto) {
+    try {
+      const { patientId, groupId, teamName } = createTeamDto;
+
+      const patient = await this.patientRepository.findOne({
+        where: { id: patientId },
+      });
+      const group = await this.groupRepository.findOne({
+        where: { id: groupId },
+      });
+
+      const team = this.teamRepository.create({
+        teamName,
+        patient,
+        group,
+      });
+
+      await this.teamRepository.save(team);
+      return { message: 'Team created successfully', team };
+    } catch (error) {
+      handleDBExceptions(error, this.logger);
+    }
   }
 
-  findAll() {
-    return `This action returns all teams`;
+  async findAll(paginationDto: PaginationDto) {
+    const { limit = 10, page = 1 } = paginationDto;
+    const offset = (page - 1) * limit;
+
+    const [teams, total] = await this.teamRepository.findAndCount({
+      take: limit,
+      skip: offset,
+    });
+
+    return { teams, total };
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} team`;
+  async findOne(id: string) {
+    const team = await this.teamRepository.findOne({ where: { id } });
+    if (!team) {
+      throw new NotFoundException(`Team with id ${id} not found`);
+    }
+    return team;
   }
 
-  update(id: number, updateTeamDto: UpdateTeamDto) {
-    return `This action updates a #${id} team`;
+  async update(id: string, updateTeamDto: UpdateTeamDto) {
+    emptyDtoException(updateTeamDto);
+
+    const team = await this.findOne(id);
+    const updatedTeam = { ...team, ...updateTeamDto };
+
+    await this.teamRepository.save(updatedTeam);
+    return { message: 'Team updated successfully', updatedTeam };
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} team`;
+  async remove(id: string) {
+    const team = await this.findOne(id);
+    await this.teamRepository.remove(team);
+    return { message: `Team with ID ${id} deleted successfully` };
   }
 }


### PR DESCRIPTION
**Descripción del PR**

Implementación de CRUDs para las entidades Groups, Patients y Teams con documentación en Swagger
Este PR incluye la implementación completa de los CRUDs para las entidades Groups, Patients y Teams, siguiendo la lógica del proyecto existente y documentando las rutas y DTOs con Swagger. A continuación se detallan los cambios realizados:

**Cambios realizados:**


`1. CRUD para la entidad Groups:
`

Creación de los DTOs CreateGroupDto y UpdateGroupDto.
Implementación del controlador GroupsController con las rutas para crear, obtener, actualizar y eliminar grupos.
Implementación del servicio GroupsService con la lógica de negocio para manejar las operaciones CRUD.
Documentación de las rutas y DTOs con Swagger.

`2. CRUD para la entidad Patients:
`

Creación de los DTOs CreatePatientDto y UpdatePatientDto.
Implementación del controlador PatientsController con las rutas para crear, obtener, actualizar y eliminar pacientes.
Implementación del servicio PatientsService con la lógica de negocio para manejar las operaciones CRUD.
Documentación de las rutas y DTOs con Swagger.

`3. CRUD para la entidad Teams:
`

Creación de los DTOs CreateTeamDto y UpdateTeamDto.
Implementación del controlador TeamsController con las rutas para crear, obtener, actualizar y eliminar equipos.
Implementación del servicio TeamsService con la lógica de negocio para manejar las operaciones CRUD.