### PR TITLE
Se fixeo el que caregiver era OnetoOne y se cambio por OneToMany

### DIFF
--- a/src/caregivers/entities/caregiver.entity.ts
+++ b/src/caregivers/entities/caregiver.entity.ts
@@ -1,5 +1,5 @@
-import { Patient } from "src/patients/entities/patient.entity";
-import { Column, Entity, OneToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Patient } from 'src/patients/entities/patient.entity';
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 
 export enum Gender {
   MALE = 'male',
@@ -8,79 +8,73 @@ export enum Gender {
 
 @Entity({ name: 'caregivers' })
 export class Caregiver {
-
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
   @Column('text', {
     unique: true,
-    nullable: false
+    nullable: false,
   })
   document: string;
 
   @Column('text', {
-    nullable: false
+    nullable: false,
   })
   name: string;
 
   @Column('text', {
-    nullable: false
+    nullable: false,
   })
   lastName: string;
 
   @Column('enum', {
     enum: Gender,
-    nullable: false
+    nullable: false,
   })
   gender: Gender;
 
   @Column('text', {
     array: true,
-    nullable: true
+    nullable: true,
   })
   conventionalNumbers: string[];
 
   @Column('text', {
     array: true,
-    nullable: true
+    nullable: true,
   })
   cellphoneNumbers: string[];
 
   @Column('text', {
-    nullable: false
+    nullable: false,
   })
   canton: string;
 
   @Column('text', {
-    nullable: false
+    nullable: false,
   })
   parish: string;
 
   @Column('text', {
-    nullable: false
+    nullable: false,
   })
   zoneType: string;
 
   @Column('text', {
-    nullable: false
+    nullable: false,
   })
   address: string;
 
   @Column('text', {
-    nullable: false
+    nullable: false,
   })
   reference: string;
 
   @Column('text', {
-    nullable: false
+    nullable: false,
   })
   patientRelationship: string;
 
-  @OneToOne(
-    () => Patient,
-    (patient) => patient.caregiver,
-    { cascade: true }
-  )
-  patient: Patient;
-
+  @OneToMany(() => Patient, (patient) => patient.caregiver, { cascade: true })
+  patients: Patient[];
 }

--- a/src/patients/entities/patient.entity.ts
+++ b/src/patients/entities/patient.entity.ts
@@ -7,6 +7,7 @@ import {
   JoinColumn,
   OneToOne,
   OneToMany,
+  ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { ConsultationInitial } from 'src/consultation/entities/consultation-initial.entity';
@@ -76,7 +77,7 @@ export class Patient {
   })
   isActive: boolean;
 
-  @OneToOne(() => Caregiver, (caregiver) => caregiver.patient, {
+  @ManyToOne(() => Caregiver, (caregiver) => caregiver.patients, {
     nullable: false,
   })
   @JoinColumn()
@@ -94,13 +95,22 @@ export class Patient {
   )
   laboratoryRequests: LaboratoryRequest[];
 
-  @OneToMany(() => ConsultationInitial, (consultationInitial) => consultationInitial.patient)
+  @OneToMany(
+    () => ConsultationInitial,
+    (consultationInitial) => consultationInitial.patient,
+  )
   consultationInitial: ConsultationInitial;
 
-  @OneToMany(() => ConsultationSubsequent, (consultationSubsequent) => consultationSubsequent.patient)
+  @OneToMany(
+    () => ConsultationSubsequent,
+    (consultationSubsequent) => consultationSubsequent.patient,
+  )
   consultationSubsequent: ConsultationSubsequent;
 
   // Nueva relación con ConsultationInternal
-  @OneToMany(() => ConsultationInternal, (consultationInternal) => consultationInternal.patient)
+  @OneToMany(
+    () => ConsultationInternal,
+    (consultationInternal) => consultationInternal.patient,
+  )
   consultationInternal: ConsultationInternal[];
 }


### PR DESCRIPTION
En la entidad Patient, la relación debe ser ManyToOne, no OneToOne. Esto es porque un paciente solo puede tener un cuidador (por eso es ManyToOne desde el lado del paciente), pero un cuidador puede tener muchos pacientes (por eso es OneToMany desde el lado del cuidador).

Ya hicimos el cambio en Patient de OneToOne a ManyToOne, así que no es necesario cambiarlo nuevamente. La configuración actual es correcta:

En Patient: ManyToOne (un paciente tiene un cuidador).
En Caregiver: OneToMany (un cuidador tiene muchos pacientes).